### PR TITLE
fix: app router is available by default now

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,7 +28,6 @@ module.exports = withBundleAnalyzer({
   swcMinify: true,
   staticPageGenerationTimeout: 180,
   experimental: {
-    appDir: true,
     serverActions: true
   },
   env: {


### PR DESCRIPTION
App router is available by default now, the "experimental.appDir" option can be safely removed.