### PR TITLE
fix: module 'Growth Path for Developers', restores the original state when the mouse leaves

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,7 +28,6 @@ module.exports = withBundleAnalyzer({
   swcMinify: true,
   staticPageGenerationTimeout: 180,
   experimental: {
-    appDir: true,
     serverActions: true
   },
   env: {

--- a/src/app/home/BuilderWay.js
+++ b/src/app/home/BuilderWay.js
@@ -75,7 +75,7 @@ function CardVerticalSlider({data, type, href}) {
   </div>
 }
 
-function Card({onMouseEnter, active, item, index}) {
+function Card({onMouseEnter, onMouseLeave, active, item, index}) {
   const router = useRouter()
   const mediaUrl = useMediaUrl()
   
@@ -86,6 +86,7 @@ function Card({onMouseEnter, active, item, index}) {
         router.push(item.href)
       }}
       onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       className={clsx('group p-8 overflow-hidden rounded-xl cursor-pointer', {
         'text-white': item.type === 'Community',
         'h-[400px] pb-0 transition-all !duration-500 mt-[-50px]': active === index,
@@ -195,6 +196,7 @@ export function BuilderWay({data}) {
           <Card
             key={`BuilderWay-card-${k}`}
             onMouseEnter={() => !media && setActive(k)}
+            onMouseLeave={() => !media && setActive(-1)}
             active={active}
             item={i}
             index={k}


### PR DESCRIPTION
The 'Growth Path for Developers' module, restores the original state when the mouse leaves.