### PR TITLE
feat: add filter by team in Quiz list

### DIFF
--- a/src/app/quiz/List.js
+++ b/src/app/quiz/List.js
@@ -23,14 +23,13 @@ import TrophiesSvg from 'public/images/trophies.svg'
 import useSWR from 'swr'
 import { fetcher } from '@/utils/request'
 import { OPagination } from '@/components/Pagination'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useDebouncedCallback } from 'use-debounce'
 import { fetchTeamList } from '#/domain/quiz/repository'
 import { ReactSelect } from '@/components/Select/ReactSelect'
 import { SearchIcon } from '@/components/Icons'
 import Input from '@/components/Input'
-import { useEffect } from 'react'
 
 
 function List({ data }) {
@@ -85,7 +84,7 @@ export function QuizList() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const [query, setQuery] = useState(searchParams?.get('search') || '')
-  const [teamUid, setTeamUid] = useState(searchParams?.get('team_uid') || '')
+  const [teamUid, setTeamUid] = useState(searchParams?.get('uid') || '')
   const [page, setPage] = useState(1)
   const [pageOffset, setPageOffset] = useState(0)
   const [selectedTeam, setSelectedTeam] = useState(null)
@@ -95,8 +94,8 @@ export function QuizList() {
   const updateUrlParams = (search, teamUid) => {
     const params = new URLSearchParams()
     if (search) params.set('search', search)
-    if (teamUid) params.set('team_uid', teamUid)
-    router.push(`/quiz?${params.toString()}`)
+    if (teamUid) params.set('uid', teamUid)
+    router.replace(`/quiz?${params.toString()}`)
   }
 
   const handleSearchChange = useDebouncedCallback(e => {
@@ -149,7 +148,7 @@ export function QuizList() {
             options={teamOptions}
             placeholder="Select Team"
             isClearable
-            isSearchable={false}
+            isSearchable
             className="w-[200px] [&>div]:pb-0"
             styles={{ control: () => ({ backgroundColor: 'transparent' }) }}
           />

--- a/src/domain/quiz/repository.js
+++ b/src/domain/quiz/repository.js
@@ -41,4 +41,8 @@ async function fetchAnsweredQuizList(params = {}) {
   })
 }
 
-export { updateRespondentContacts, fetchPublishedQuizList, fetchAnsweredQuizList }
+async function fetchTeamList(){
+  return httpClient.get('/quiz/team')
+}
+
+export { updateRespondentContacts, fetchPublishedQuizList, fetchAnsweredQuizList, fetchTeamList }


### PR DESCRIPTION
### 变更内容
1. 在 Quiz 列表中新增了按发布人筛选的功能：
   - 使用 ReactSelect 实现可搜索的下拉列表。
   - 筛选条件会保存在 URL 中，支持页面刷新后保留筛选结果。
   - 为了保持一致性，把 search 也添加在 URL 中
2. 发布人列表数据通过 `/quiz/team` 接口获取：
   - 在 `src/domain/quiz/repository.js` 中新增了异步函数处理数据。
   - 在 `src/app/quiz/List.js` 中实现了下拉筛选

### 测试步骤
1. 打开 Quiz 列表页面。
2. 使用新增的下拉列表按发布人筛选数据。
3. 确认筛选条件正确保存在 URL 中。
4. 刷新页面，确保筛选结果仍然有效。

### 相关 Issue
Closes #57