### PR TITLE
fix(quiz): fix bug in multi-select cancel logic

### DIFF
--- a/src/domain/quiz/views/quiz-question-list/QuizCore.js
+++ b/src/domain/quiz/views/quiz-question-list/QuizCore.js
@@ -41,8 +41,10 @@ export function QuizCore({
     const _quiz = [...quiz];
 
     if (multiple) {
-      if (_quiz[page - 1].answer.includes(item.id)) {
-        _quiz[page - 1].answer.splice( _quiz.indexOf(item.id), 1);
+      const answerIndex = _quiz[page - 1].answer.indexOf(item.id);
+
+      if (answerIndex !== -1) {
+        _quiz[page - 1].answer.splice(answerIndex, 1);
       } else {
         _quiz[page - 1].answer.push(item.id);
       }


### PR DESCRIPTION
#208 

修复 quiz 多选题中，取消选项异常bug。

原逻辑中使用了 `indexOf` 查找选项在 quiz 数组中的位置，导致无法正确删除选项。

本次修改将其替换为在当前题目的 answer 数组中查找选项  id。