### PR TITLE
fix: remove THUBA from university partners

### DIFF
--- a/src/app/home/Trusted.js
+++ b/src/app/home/Trusted.js
@@ -39,6 +39,7 @@ function readyPartnersData() {
     />});
   }
   for (let i = 1; i <= 20; i++) {
+    if (i === 14) continue;
     partnersData.University.push({ ele: <NextImage
       className="max-w-[160px] max-h-[40px]"
       width={160}


### PR DESCRIPTION
## Summary
- Remove THUBA from the homepage University partner list by skipping University 014.svg

## Test
- Static verification: University list count is 19 and University 014.svg is absent
- Visual contact sheet verified 014/THUBA is not rendered